### PR TITLE
Add missing PersistentStoreProtocol.swift file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,9 +72,9 @@ playground.xcworkspace
 
 Carthage/Build/
 
-# Accio dependency management
-Dependencies/
-.accio/
+## Accio dependency management
+#Dependencies/
+#.accio/
 
 # fastlane
 # It is recommended to not store the screenshots in the git repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - README.md.
+- PersistentStoreProtocol.swift.
+
+### Fixed
+
+- Removed `Dependencies` from .gitignore. 

--- a/Sources/Features/HeroDetail/dependencies/PersistentStoreProtocol.swift
+++ b/Sources/Features/HeroDetail/dependencies/PersistentStoreProtocol.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// A persistent key-value store.
+///
+/// sourcery: AutoMockable
+protocol PersistentStoreProtocol
+{
+    func set(_ value: Bool, forKey defaultName: String)
+    func bool(forKey defaultName: String) -> Bool
+}
+
+extension UserDefaults: PersistentStoreProtocol
+{}


### PR DESCRIPTION
### What’s Changed

- removed `Dependencies` from .gitignore.
- Tracked PersistentStoreProtocol.swift file.

### Why This Change

- The build was broken because the missing file.